### PR TITLE
update gofish version to support supermicro oem

### DIFF
--- a/collector/chassis_collector.go
+++ b/collector/chassis_collector.go
@@ -278,7 +278,7 @@ func parseChassisTemperature(ch chan<- prometheus.Metric, chassisID string, chas
 	ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_celsius"].desc, prometheus.GaugeValue, float64(chassisTemperatureReadingCelsius), chassisTemperatureLabelvalues...)
 }
 
-func parseChassisFan(ch chan<- prometheus.Metric, chassisID string, chassisFan redfish.Fan, wg *sync.WaitGroup) {
+func parseChassisFan(ch chan<- prometheus.Metric, chassisID string, chassisFan redfish.ThermalFan, wg *sync.WaitGroup) {
 	defer wg.Done()
 	chassisFanID := chassisFan.MemberID
 	chassisFanName := chassisFan.Name
@@ -425,7 +425,7 @@ func parseNetworkPort(ch chan<- prometheus.Metric, chassisID string, networkPort
 	networkPhysicalPortNumber := networkPort.PhysicalPortNumber
 	chassisNetworkPortLabelValues := []string{"network_port", chassisID, networkAdapterName, networkAdapterID, networkPortName, networkPortID, string(networkPortLinkType), networkPortLinkSpeed, string(networkPortConnectionType), networkPhysicalPortNumber}
 
-	if networkLinkStatusValue, ok := parsePortLinkStatus(networkLinkStatus); ok {
+	if networkLinkStatusValue, ok := parsePortLinkStatus(redfish.PortLinkStatus(networkLinkStatus)); ok {
 		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_network_port_link_state"].desc, prometheus.GaugeValue, networkLinkStatusValue, chassisNetworkPortLabelValues...)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golangci/golangci-lint v1.58.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/exporter-toolkit v0.7.2
-	github.com/stmcginnis/gofish v0.15.0
+	github.com/stmcginnis/gofish v0.20.0
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/ssgreg/nlreturn/v2 v2.2.1 h1:X4XDI7jstt3ySqGU86YGAURbxw3oTDPK9sPEi6YE
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm07ysF0U6JQXczc=
 github.com/stbenjam/no-sprintf-host-port v0.1.1/go.mod h1:TLhvtIvONRzdmkFiio4O8LHsN9N74I+PhRquPsxpL0I=
-github.com/stmcginnis/gofish v0.15.0 h1:8TG41+lvJk/0Nf8CIIYErxbMlQUy80W0JFRZP3Ld82A=
-github.com/stmcginnis/gofish v0.15.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
+github.com/stmcginnis/gofish v0.20.0 h1:hH2V2Qe898F2wWT1loApnkDUrXXiLKqbSlMaH3Y1n08=
+github.com/stmcginnis/gofish v0.20.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
  Description:
  This PR updates the github.com/stmcginnis/gofish dependency from v0.15.0 to v0.20.0 to gain access to recent improvements  and expanded hardware support.

  What changed:
  - Updated go.mod to use gofish v0.20.0
  - Fixed breaking API changes:
    - Updated parseChassisFan function signature to use redfish.ThermalFan instead of redfish.Fan (chassis_collector.go:281)
    - Added type conversion for NetworkPortLinkStatus to PortLinkStatus (chassis_collector.go:428)

  Why this update is needed:
  - Adds support for Supermicro OEM objects (ComputerSystem, Chassis, Manager, AccountService, UpdateService, DumpService)
  - Improves Drive and PCIeDevice/PCIeFunction OEM data exposure
  - Updates to Redfish 2023.3 schema bundle for better compatibility with modern hardware
  - Includes various bug fixes and stability improvements from versions v0.16.0 through v0.20.0

  ⚠️ Important Compatibility Note:
  The gofish v0.20.0 library changed fan threshold and reading values from float32 to int. This means:
  - Fan RPM values that were previously reported as decimals (e.g., 2150.5 RPM) will now be truncated to integers (2150 RPM)
  - This affects: Reading, LowerThresholdCritical, LowerThresholdFatal, UpperThresholdCritical, UpperThresholdFatal,
  MinReadingRange, MaxReadingRange
  - Recommended: Test with your hardware to ensure fan monitoring and alerting thresholds still work as expected
  - This change comes from upstream gofish library and aligns with the Redfish specification

  Testing:
  - Build completes successfully
  - All existing tests pass
  - No functional changes to the exporter's behavior (aside from int truncation noted above)
  - Confirmed this resolves issue we were seeing with json unmarshalling
  ```
  time=2025-08-11T16:38:06.486Z level=ERROR msg="error getting processor data from system" target=10.0.0.1 collector=SystemCollector System=HGX_Baseboard_0 operation=system.Processors() error="failed to retrieve some items: [{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_2\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_3\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_4\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_5\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_6\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_7\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"},{\"link\":\"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_8\",\"error\":\"json: cannot unmarshal object into Go struct field t1.Actions of type string\"}]"
  ```